### PR TITLE
fix: Resolve NameError crash on startup

### DIFF
--- a/zurvan.py
+++ b/zurvan.py
@@ -83,7 +83,7 @@ from PyQt6.QtWidgets import (
     QTreeWidget, QTreeWidgetItem, QSplitter, QFileDialog, QMessageBox, QComboBox,
     QListWidget, QListWidgetItem, QScrollArea, QLineEdit, QCheckBox, QFrame, QMenu, QTextEdit, QGroupBox,
     QProgressBar, QTextBrowser, QRadioButton, QButtonGroup, QFormLayout, QGridLayout, QDialog,
-    QHeaderView, QInputDialog, QGraphicsOpacityEffect, QStackedWidget, QToolButton, QTableView
+    QHeaderView, QInputDialog, QGraphicsOpacityEffect, QStackedWidget, QToolButton, QTableView, QDateEdit
 )
 from ai_tab import AIAssistantTab, AISettingsDialog, AIGuideDialog
 from login import LoginDialog


### PR DESCRIPTION
This commit fixes a `NameError: name 'QDateEdit' is not defined` that occurred when initializing the main application window after login.

The `QDateEdit` widget was used in the `CveViewerWidget` for date-based filtering but was not imported from `PyQt6.QtWidgets`. This commit adds the missing import, resolving the crash.

This also unblocks the user from seeing the other recently implemented features that were not visible due to the main window failing to load.