### PR TITLE
fix: Resolve TypeError in CveViewerWidget

### DIFF
--- a/zurvan.py
+++ b/zurvan.py
@@ -1105,9 +1105,9 @@ class CveTableModel(QAbstractTableModel):
             return self.headers[section]
         return None
 
-    def load_data(self, filter_text, sort_column, sort_order, page, page_size):
+    def load_data(self, filter_text, sort_column, sort_order, page, page_size, cvss_min=None, cvss_max=None, date_from=None, date_to=None):
         self.beginResetModel()
-        self.cves = database.get_cve_data(filter_text, sort_column, sort_order, page, page_size)
+        self.cves = database.get_cve_data(filter_text, sort_column, sort_order, page, page_size, cvss_min, cvss_max, date_from, date_to)
         self.endResetModel()
 
 class CveViewerWidget(QWidget):


### PR DESCRIPTION
This commit fixes a `TypeError` that occurred when trying to view the offline CVE database. The `CveTableModel.load_data` method was being called with more arguments than its definition accepted.

This was caused by a previous change where the advanced filtering logic was added to the `CveViewerWidget`, but the corresponding model method was not updated.

This change updates the `load_data` method signature to accept the new filter parameters (cvss_min, cvss_max, date_from, date_to) and correctly passes them to the underlying database query function. This resolves the crash and enables the advanced filtering functionality.